### PR TITLE
Add ACTION reward type to defaults

### DIFF
--- a/src/tau2/data_model/tasks.py
+++ b/src/tau2/data_model/tasks.py
@@ -271,7 +271,7 @@ class EvaluationCriteria(BaseModel):
         list[RewardType],
         Field(
             description="The basis of the reward. This will be used to determine the reward for the task.",
-            default_factory=lambda: [RewardType.DB, RewardType.COMMUNICATE],
+            default_factory=lambda: [RewardType.DB, RewardType.COMMUNICATE, RewardType.ACTION],
         ),
     ]
 


### PR DESCRIPTION
## TODO

- [x] Test impact on Qwen3
- [x] Test impact on baseline
- [x] Test impact on Hermes model

## Comparisons (with action rewards vs without)

Note: all scores below use `Qwen/Qwen3-30B-A3B-Instruct-2507` as the user agent!

**Qwen3-4B-Instruct-2507**
- Airline: 0.255 vs 0.29
- Retail: 0.158 vs 0.29
- Telecom: 0.138 vs 0.123

**Qwen3-4B-Instruct-Agentic_hermes2-step-000001410**
- Airline: 0.115 vs 0.39 
- Retail: 0.011 vs 0.061
- Telecom: 0.037 vs 0.032